### PR TITLE
Fix typo in footnote link

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ layout: default
             These signatures are checked against a small set of trusted keys
             already stored on your computer. Downloaded files are rejected by
             APT if they are signed by an unknown
-            key<sup class="ref"><a href="#footnote-apt-unkown-key">[1]</a></sup> or are missing
+            key<sup class="ref"><a href="#footnote-apt-unknown-key">[1]</a></sup> or are missing
             valid signatures. This ensures that the packages you are
             installing were authorised by your distribution and have not been
             modified or replaced since.


### PR DESCRIPTION
Link wasn't working before